### PR TITLE
Built in gcc func for faster msb function

### DIFF
--- a/list.h
+++ b/list.h
@@ -11,18 +11,8 @@ typedef unsigned int uint;
 typedef unsigned char* dataptr;
 #endif
 
-uint msb( uint v ) // most significant bit
-{
-	if( !v ) return 0;
-	v = ( v << 1 ) - 1;
 
-	unsigned r = 0;
-	while( v >>= 1 )
-	{
-		r++;
-	}
-	return r;
-}
+#define msb( v ) (!v) ? 0 : 32-__builtin_clz(v)
 
 typedef struct list_s
 {


### PR DESCRIPTION
gcc built ins are hella fast.


Profiling code:
```
int main()
{
    unsigned long long tot;
    clock_t start = clock();
    tot=0;
    for (int i =0; i<1000000; i++){
        tot+=msb2(i);
    }
    clock_t end = clock();
    double msb2prof = (end-start)/(double)CLOCKS_PER_SEC;
    start = clock();
    tot=0;
    for (int i =0; i<1000000; i++){
        tot+=msb(i);
    }
    end = clock();
    double msbprof = (end-start)/(double)CLOCKS_PER_SEC;
    
    printf("%f\n%f",msbprof,msb2prof);
    return 0;
}
```

Results:
```
old msb: 0.040971
new msb: 0.002739
```